### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/routes/picture.py
+++ b/routes/picture.py
@@ -89,6 +89,9 @@ def upload_picture():
         db.commit()
     db.close()
 
-    file.save(os.path.join(PICTURE_FOLDER, hexname))
+    fullpath = os.path.normpath(os.path.join(PICTURE_FOLDER, hexname))
+    if not fullpath.startswith(PICTURE_FOLDER):
+        return jsonify({"error": "Invalid file path"}), 400
+    file.save(fullpath)
 
     return jsonify({"picture_path": hexname}), 201


### PR DESCRIPTION
Fixes [https://github.com/TheSmartCooking/API/security/code-scanning/2](https://github.com/TheSmartCooking/API/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within the `PICTURE_FOLDER` directory. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the `PICTURE_FOLDER` directory. This will prevent any path traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
